### PR TITLE
fix: readme dotrisk link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # 🛠️ Restaking.risk Metadata Update Guide
 
-Welcome! 👋 This repository exists to help **AVS (Actively Validated Service) providers** contribute metadata about their reward and slashing policies to [Dotrisk](https://restaking-risk.vercel.app/), a public dashboard powered by A41 restaking insights.
+Welcome! 👋 This repository exists to help **AVS (Actively Validated Service) providers** contribute metadata about their reward and slashing policies to [Dotrisk](https://restaking.dotrisk.xyz/), a public dashboard powered by A41 restaking insights.
 
 We want to make sure your AVS is accurately represented, and that the wider community can understand and evaluate your protocol’s mechanisms.
 


### PR DESCRIPTION
## Description
The Dotrisk link in the README was outdated.  
This PR updates the link from [Dotrisk (old)](https://restaking-risk.vercel.app/) to [Dotrisk (new)](https://restaking.dotrisk.xyz/).

---

## Changes
- Updated the Dotrisk link in the README file.

---

## Motivation and Context
The previous Dotrisk link was pointing to outdated information.  
The new link leads to the updated and maintained Dotrisk page.

---

## Related Issue
N/A

---

## Checklist
- [x] Updated documentation (if necessary)
- [ ] Added tests (if necessary)
- [x] Ensured that the change does not break existing functionality